### PR TITLE
Fix typo in off method

### DIFF
--- a/src/modules/colorPicker.js
+++ b/src/modules/colorPicker.js
@@ -192,7 +192,7 @@ colorPicker.prototype = {
   */
   off: function(eventType, callback) {
     var eventList = this._events[eventType];
-    if (eventList) evenList.splice(eventList.indexOf(callback), 1);
+    if (eventList) eventList.splice(eventList.indexOf(callback), 1);
   },
 
   /**


### PR DESCRIPTION
* .off() method fails because evenList is not defined. Correct variable
  name to eventList.