### PR TITLE
Update events API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 ### Changelog
 
+#### 4.3.0
+
+##### Additions
+
+* New events added:
+  * `input:change` - The same as `color:change`, but only fires when the color has been set with user input
+  * `color:init` - Same as `color:change`, but fired once with the initial color value
+* colorPicker methods:
+  * `on` and `off` methods can now take arrays of eventTypes as well as strings
+  * New `deferredEmit` method (should only be used by plugins)
+
+##### Changes
+
+The `color:change` event no longer fires with the initial color value, as this was catching a few people out.
+
+If you need to reproduce previous behaviour, please make sure to listen for both `color:init` and `color:change` events with the same listener, like so:
+
+```js
+colorPicker.on(['color:init', 'color:change'], function(color, change) {
+  // do whatever
+});
+```
+
 #### 4.2.2
 
 ##### Fixes

--- a/index.html
+++ b/index.html
@@ -50,6 +50,14 @@
       demo.on('color:change', function() {
         console.log('color:change');
       })
+
+      demo.on('input:change', function(color) {
+        console.log('input:change');
+      })
+
+      demo.on(['color:init', 'color:change'], function() {
+        console.log('color:change or color:init');
+      })
     </script>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jaames/iro",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "description": "An HSV color picker widget for JavaScript, with a modern SVG-based user interface",
   "module": "dist/iro.es.js",
   "main": "dist/iro.js",

--- a/src/colorPicker.js
+++ b/src/colorPicker.js
@@ -43,14 +43,20 @@ class ColorPicker extends Component {
    */
   on(eventList, callback) {
     const events = this._events;
+    // eventList can be an eventType string or an array of eventType strings
     (!Array.isArray(eventList) ? [eventList] : eventList).forEach(eventType => {
+      // Emit plugin hook
       this.emitHook('event:on', eventType, callback);
+      // Add event callback
       (events[eventType] || (events[eventType] = [])).push(callback);
       // Call deferred events
+      // These are events that can be stored until a listener for them is added
       if (this._deferredEvents[eventType]) {
+        // Deffered events store an array of arguments from when the event was called
         this._deferredEvents[eventType].forEach(args => {
           callback.apply(null, args); 
         });
+        // Clear deferred events
         this._deferredEvents[eventType] = [];
       }
     });
@@ -159,10 +165,10 @@ class ColorPicker extends Component {
     this.emitHook('color:afterUpdate', color, changes);
     // Prevent infinite loops if the color is set inside a color:change or input:change callback
     if (!this._colorUpdateActive) {
-      // While _colorUpdateActive == true, this event cannot be fired
+      // While _colorUpdateActive == true, branch cannot be entered
       this._colorUpdateActive = true;
       // If the color change originates from user input, fire input:change
-      if (this._colorUpdateSrc == 'input') {
+      if (this._colorUpdateSrc == 'input') { // colorUpdateSrc is cleared in handeInput()
         this.emit('input:change', color, changes);
       } 
       // Always fire color:change event


### PR DESCRIPTION
* New events added:
  * `input:change` - The same as `color:change`, but only fires when the color has been set with user input
  * `color:init` - Same as `color:change`, but fired once with the initial color value
* colorPicker methods:
  * `on` and `off` methods can now take arrays of eventTypes as well as strings
  * New `deferredEmit` method (should only be used by plugins)