### PR TITLE
Added Github Actions CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@
   <a href="">
     <img src="https://badgen.net/badge/jQuery/none/F8AE55" alt="no jQuery" />
   </a>
+  <a href="https://github.com/jaames/iro.js/actions/workflows/markdown-autodocs.yml" target="_blank">
+     <img src="https://github.com/jaames/iro.js/workflows/markdown-autodocs/badge.svg" alt="Deployment">
+  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Added Github actions CI badge for markdown-autodocs workflow. Even in the future if you're planning to run automated tests using Github action, it would be better to add a pipeline status badge in the readme. It would be very helpful information for the developer community who are using your project.